### PR TITLE
Fixing tests and topology

### DIFF
--- a/network-cicd/tests/validation_tasks.robot
+++ b/network-cicd/tests/validation_tasks.robot
@@ -38,20 +38,20 @@ Ping
 
 # Verify OSPF neighbor counts
 Verify Ospf neighbors dist1
-    verify count "2" "ospf neighbors" on device "dist1"
+    verify count "6" "ospf neighbors" on device "dist1"
 Verify Ospf neighbors dist2
-    verify count "2" "ospf neighbors" on device "dist2"
+    verify count "6" "ospf neighbors" on device "dist2"
 Verify Ospf neighbors core1
-    verify count "2" "ospf neighbors" on device "core1"
+    verify count "3" "ospf neighbors" on device "core1"
 Verify Ospf neighbors core2
-    verify count "2" "ospf neighbors" on device "core1"
+    verify count "3" "ospf neighbors" on device "core1"
 
 
 # Verify Interfaces
 Verify Interface dist1
-    verify count "12" "interface up" on device "dist1"
+    verify count "15" "interface up" on device "dist1"
 Verify Interface dist2
-    verify count "13" "interface up" on device "dist2"
+    verify count "15" "interface up" on device "dist2"
 Verify Interface core1
     verify count "5" "interface up" on device "core1"
 Verify Interface core2

--- a/network-cicd/virl/prod/topology.virl
+++ b/network-cicd/virl/prod/topology.virl
@@ -147,7 +147,23 @@ interface mgmt0
     ip route 0.0.0.0/0 172.16.30.254
   hardware forwarding unicast trace
 
-  interface mgmt0
+  interface Ethernet1/1
+    no shutdown
+
+  interface Ethernet1/2
+    no shutdown
+
+  interface Ethernet1/3
+    no shutdown
+
+  interface Ethernet1/4
+    no shutdown
+
+  interface Ethernet1/5
+    no shutdown
+
+  interface Ethernet1/6
+    no shutdown  interface mgmt0
     description OOB Management
     ! Configured on launch
     no ip address

--- a/network-cicd/virl/test/topology.virl
+++ b/network-cicd/virl/test/topology.virl
@@ -29,7 +29,23 @@ vrf context management
   ip route 0.0.0.0/0 172.16.30.254
 hardware forwarding unicast trace
 
-interface mgmt0
+interface Ethernet1/1
+  no shutdown
+
+interface Ethernet1/2
+  no shutdown
+
+interface Ethernet1/3
+  no shutdown
+
+interface Ethernet1/4
+  no shutdown
+
+interface Ethernet1/5
+  no shutdown
+
+interface Ethernet1/6
+  no shutdowninterface mgmt0
   description OOB Management
   ! Configured on launch
   no ip address


### PR DESCRIPTION
Fixes for pyATS tests on interface and OSPF counts.  and enable all interfaces on nx-os switches in topologies.  